### PR TITLE
Raise Errors on Missing Translations

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,5 +39,5 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 end


### PR DESCRIPTION
The B2B plugin had a lot of invalid i18n keys that could have been caught in the mega-build, so other plugins wouldn't suffer from test failures related to translation issues in other gems. To remedy this, always raise errors on missing translations, so that even if the plugin doesn't have this turned on, we'll eventually catch it in the megabuild before it's released and breaking tests for our users.